### PR TITLE
Add full implementation of seen module with authentication, validation, and route integration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import { movieRoutes } from './routes/movieRoutes';
 import { bookRoutes } from './routes/bookRoutes';
 import { commentRoutes } from './routes/commentRoutes';
 import { ratingRoutes } from './routes/ratingRoutes';
+import { seenRoutes } from './routes/seenRoutes';
 
 config();
 
@@ -106,6 +107,7 @@ app.register(movieRoutes, { prefix: '/api/v1/movies' });
 app.register(bookRoutes, { prefix: '/api/v1/books' });
 app.register(commentRoutes, { prefix: '/api/v1/comments' });
 app.register(ratingRoutes, { prefix: '/api/v1/ratings' });
+app.register(seenRoutes, { prefix: '/api/v1/seen' });
 
 app.get('/api/v1/ping', async () => {
     return { status: 'ok' };

--- a/src/controllers/seenControllers.ts
+++ b/src/controllers/seenControllers.ts
@@ -1,0 +1,47 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import { AuthenticatedUser } from "../middleware/auth";
+
+export const postSeen = async (request: FastifyRequest, reply: FastifyReply) => {
+    const { movie_id, book_id } = request.body as { movie_id: number | null, book_id: number | null };
+
+    const decoded = await request.jwtVerify<AuthenticatedUser>();
+
+    const client = await request.server.pg.connect();
+    try {
+        const { rows: existingSeenRows } = await client.query('SELECT * FROM seen WHERE user_id = $1 AND movie_id = $2 AND book_id = $3', [decoded.id, movie_id, book_id]);
+        if (existingSeenRows.length > 0) {
+            return reply.code(400).send({ message: 'Seen already exists' });
+        }
+
+        const { rows: newSeenRows } = await client.query('INSERT INTO seen (user_id, movie_id, book_id) VALUES ($1, $2, $3) RETURNING *', [decoded.id, movie_id, book_id]);
+        return newSeenRows[0];
+    } catch (error) {
+        return reply.code(500).send({ message: 'Internal server error' });
+    } finally {
+        client.release();
+    }
+}
+
+export const deleteSeen = async (request: FastifyRequest, reply: FastifyReply) => {
+    const { id } = request.params as { id: number };
+
+    const decoded = await request.jwtVerify<AuthenticatedUser>();
+
+    const client = await request.server.pg.connect();
+    try {
+        const { rows: existingSeenRows } = await client.query('SELECT * FROM seen WHERE id = $1 AND user_id = $2', [id, decoded.id]);
+        if (existingSeenRows.length === 0) {
+            return reply.code(404).send({ message: 'Seen not found' });
+        }
+        if (existingSeenRows[0].user_id !== decoded.id) {
+            return reply.code(403).send({ message: 'You are not the owner of this seen' });
+        }
+
+        await client.query('DELETE FROM seen WHERE id = $1 AND user_id = $2', [id, decoded.id]);
+        return reply.code(204).send();
+    } catch (error) {
+        return reply.code(500).send({ message: 'Internal server error' });
+    } finally {
+        client.release();
+    }
+}

--- a/src/dtos/seenDtos.ts
+++ b/src/dtos/seenDtos.ts
@@ -1,0 +1,54 @@
+import { FastifySchema } from "fastify";
+import { error400, error401, error403, error404, error500 } from "../utils/errorTypes";
+
+export const postSeenSchema: FastifySchema = {
+    description: 'Post a seen',
+    tags: ['Seen'],
+    security: [{ bearerAuth: [] }],
+    body: {
+        type: 'object',
+        properties: {
+            movie_id: { type: 'number', nullable: true },
+            book_id: { type: 'number', nullable: true }
+        }
+    },
+    response: {
+        200: {
+            description: 'Seen posted successfully',
+            type: 'object',
+            properties: {
+                id: { type: 'number' },
+                user_id: { type: 'number' },
+                movie_id: { type: 'number', nullable: true },
+                book_id: { type: 'number', nullable: true }
+            }
+        },
+        400: error400,
+        401: error401,
+        403: error403,
+        404: error404,
+        500: error500
+    }
+}
+
+export const deleteSeenSchema: FastifySchema = {
+    description: 'Delete a seen',
+    tags: ['Seen'],
+    security: [{ bearerAuth: [] }],
+    params: {
+        type: 'object',
+        properties: {
+            id: { type: 'number' }
+        }
+    },
+    response: {
+        204: {
+            description: 'Seen deleted successfully'
+        },
+        400: error400,
+        401: error401,
+        403: error403,
+        404: error404,
+        500: error500
+    }
+}

--- a/src/routes/seenRoutes.ts
+++ b/src/routes/seenRoutes.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from "fastify";
+import { deleteSeen, postSeen } from "../controllers/seenControllers";
+import { deleteSeenSchema, postSeenSchema } from "../dtos/seenDtos";
+import { authenticate } from "../middleware/auth";
+
+export const seenRoutes = (fastify: FastifyInstance) => {
+    fastify.post('/', {
+        schema: postSeenSchema,
+        preHandler: [authenticate]
+    }, postSeen);
+
+    fastify.delete('/:id', {
+        schema: deleteSeenSchema,
+        preHandler: [authenticate]
+    }, deleteSeen);
+}


### PR DESCRIPTION
## Summary
This PR introduces the complete implementation of the seen module, enabling users to mark books or movies as “seen” and manage those records securely. It ensures proper validation, authentication, and route registration, and integrates the module into the API with consistent schema support.

## ✨ Features Added

### Post a seen (movie or book)
	•	Route: POST /seen
	•	Access: Authenticated users only
	•	Behavior: Adds a “seen” record for a movie or book, preventing duplicates
	•	Schema: postSeenSchema

### Delete a seen (by ID)
	•	Route: DELETE /seen/:id
	•	Access: Authenticated user must be the owner
	•	Behavior: Deletes a specific “seen” record if it exists and belongs to the user
	•	Schema: deleteSeenSchema

## 📦 Routing Integration
	•	File: seenRoutes.ts
	•	Behavior: Registers both POST and DELETE endpoints under /api/v1/seen
	•	Middleware: JWT authentication (authenticate) applied to all routes
	•	Registered in main app under: app.register(seenRoutes, { prefix: '/api/v1/seen' });

## 📚 Documentation & Validation
	•	All routes include corresponding Fastify schemas
	•	Ensures input validation, status documentation, and OpenAPI/Swagger compatibility

## ✅ Notes
	•	Seen records cannot be duplicated (per user/movie/book combination)
	•	All operations protected with jwtVerify()
	•	Ownership checks enforced before deletion
	•	Seen module is now fully operational and consistent with the rest of the API architecture