### PR TITLE
Test/seen

### DIFF
--- a/src/controllers/seenControllers.ts
+++ b/src/controllers/seenControllers.ts
@@ -2,46 +2,67 @@ import { FastifyReply, FastifyRequest } from "fastify";
 import { AuthenticatedUser } from "../middleware/auth";
 
 export const postSeen = async (request: FastifyRequest, reply: FastifyReply) => {
-    const { movie_id, book_id } = request.body as { movie_id: number | null, book_id: number | null };
-
-    const decoded = await request.jwtVerify<AuthenticatedUser>();
-
-    const client = await request.server.pg.connect();
     try {
-        const { rows: existingSeenRows } = await client.query('SELECT * FROM seen WHERE user_id = $1 AND movie_id = $2 AND book_id = $3', [decoded.id, movie_id, book_id]);
-        if (existingSeenRows.length > 0) {
-            return reply.code(400).send({ message: 'Seen already exists' });
+        const { movie_id, book_id } = request.body as { movie_id: number | null, book_id: number | null };
+        const decoded = await request.jwtVerify<AuthenticatedUser>();
+
+        if (movie_id === null && book_id === null) {
+            return reply.code(400).send({ message: 'Either movie_id or book_id must be provided' });
         }
 
-        const { rows: newSeenRows } = await client.query('INSERT INTO seen (user_id, movie_id, book_id) VALUES ($1, $2, $3) RETURNING *', [decoded.id, movie_id, book_id]);
-        return newSeenRows[0];
+        const client = await request.server.pg.connect();
+        try {
+            let existingSeenQuery;
+            let existingSeenParams;
+
+            if (movie_id !== null) {
+                existingSeenQuery = 'SELECT * FROM seen WHERE user_id = $1 AND movie_id = $2 AND book_id IS NULL';
+                existingSeenParams = [decoded.id, movie_id];
+            } else {
+                existingSeenQuery = 'SELECT * FROM seen WHERE user_id = $1 AND book_id = $2 AND movie_id IS NULL';
+                existingSeenParams = [decoded.id, book_id];
+            }
+
+            const { rows: existingSeenRows } = await client.query(existingSeenQuery, existingSeenParams);
+            if (existingSeenRows.length > 0) {
+                return reply.code(400).send({ message: 'Seen already exists' });
+            }
+
+            const { rows: newSeenRows } = await client.query('INSERT INTO seen (user_id, movie_id, book_id) VALUES ($1, $2, $3) RETURNING id, user_id, movie_id, book_id, seen_at', [decoded.id, movie_id, book_id]);
+            return reply.code(200).send(newSeenRows[0]);
+        } catch (error) {
+            return reply.code(500).send({ message: 'Internal server error' });
+        } finally {
+            client.release();
+        }
     } catch (error) {
-        return reply.code(500).send({ message: 'Internal server error' });
-    } finally {
-        client.release();
+        return reply.code(401).send({ message: 'Unauthorized' });
     }
 }
 
 export const deleteSeen = async (request: FastifyRequest, reply: FastifyReply) => {
-    const { id } = request.params as { id: number };
-
-    const decoded = await request.jwtVerify<AuthenticatedUser>();
-
-    const client = await request.server.pg.connect();
     try {
-        const { rows: existingSeenRows } = await client.query('SELECT * FROM seen WHERE id = $1 AND user_id = $2', [id, decoded.id]);
-        if (existingSeenRows.length === 0) {
-            return reply.code(404).send({ message: 'Seen not found' });
-        }
-        if (existingSeenRows[0].user_id !== decoded.id) {
-            return reply.code(403).send({ message: 'You are not the owner of this seen' });
-        }
+        const { id } = request.params as { id: number };
+        const decoded = await request.jwtVerify<AuthenticatedUser>();
 
-        await client.query('DELETE FROM seen WHERE id = $1 AND user_id = $2', [id, decoded.id]);
-        return reply.code(204).send();
+        const client = await request.server.pg.connect();
+        try {
+            const { rows: existingSeenRows } = await client.query('SELECT * FROM seen WHERE id = $1', [id]);
+            if (existingSeenRows.length === 0) {
+                return reply.code(404).send({ message: 'Seen not found' });
+            }
+            if (existingSeenRows[0].user_id !== decoded.id) {
+                return reply.code(403).send({ message: 'You are not the owner of this seen' });
+            }
+
+            await client.query('DELETE FROM seen WHERE id = $1 AND user_id = $2', [id, decoded.id]);
+            return reply.code(204).send();
+        } catch (error) {
+            return reply.code(500).send({ message: 'Internal server error' });
+        } finally {
+            client.release();
+        }
     } catch (error) {
-        return reply.code(500).send({ message: 'Internal server error' });
-    } finally {
-        client.release();
+        return reply.code(401).send({ message: 'Unauthorized' });
     }
 }

--- a/tests/seen.test.ts
+++ b/tests/seen.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import app from '../src/app';
+import { sign } from 'jsonwebtoken';
+
+describe('📦 Test Suite: seen.test.ts', () => {
+    let adminToken: string;
+    let userToken: string;
+    let anotherUserToken: string;
+    let testMovieId: number;
+    let testBookId: number;
+    let testSeenId: number;
+
+    beforeAll(async () => {
+        await app.ready();
+
+        const uniqueId = Date.now();
+
+        const adminRegisterResponse = await app.inject({
+            method: 'POST',
+            url: '/api/v1/auth/register',
+            payload: {
+                username: `testadmin${uniqueId}`,
+                email: `testadmin${uniqueId}@example.com`,
+                password: 'password123'
+            }
+        });
+        const adminUser = JSON.parse(adminRegisterResponse.payload);
+
+        const userRegisterResponse = await app.inject({
+            method: 'POST',
+            url: '/api/v1/auth/register',
+            payload: {
+                username: `testuser${uniqueId}`,
+                email: `testuser${uniqueId}@example.com`,
+                password: 'password123'
+            }
+        });
+        const normalUser = JSON.parse(userRegisterResponse.payload);
+
+        const anotherUserRegisterResponse = await app.inject({
+            method: 'POST',
+            url: '/api/v1/auth/register',
+            payload: {
+                username: `anothertestuser${uniqueId}`,
+                email: `anothertestuser${uniqueId}@example.com`,
+                password: 'password123'
+            }
+        });
+        const anotherUser = JSON.parse(anotherUserRegisterResponse.payload);
+
+        adminToken = sign(
+            { id: adminUser.id, username: adminUser.username, email: adminUser.email, is_admin: true },
+            process.env.JWT_SECRET || 'test-secret',
+            { expiresIn: '1h' }
+        );
+
+        userToken = sign(
+            { id: normalUser.id, username: normalUser.username, email: normalUser.email, is_admin: false },
+            process.env.JWT_SECRET || 'test-secret',
+            { expiresIn: '1h' }
+        );
+
+        anotherUserToken = sign(
+            { id: anotherUser.id, username: anotherUser.username, email: anotherUser.email, is_admin: false },
+            process.env.JWT_SECRET || 'test-secret',
+            { expiresIn: '1h' }
+        );
+
+        const movieResponse = await app.inject({
+            method: 'POST',
+            url: '/api/v1/movies',
+            headers: {
+                authorization: `Bearer ${adminToken}`
+            },
+            payload: {
+                title: 'Test Movie for Seen',
+                cover_image: 'test.jpg',
+                description: 'A test movie',
+                director: 'Test Director',
+                release_date: '2023-01-01',
+                genre: 'Action'
+            }
+        });
+        const movieData = JSON.parse(movieResponse.payload);
+        testMovieId = movieData.id;
+
+        const bookResponse = await app.inject({
+            method: 'POST',
+            url: '/api/v1/books',
+            headers: {
+                authorization: `Bearer ${adminToken}`
+            },
+            payload: {
+                title: 'Test Book for Seen',
+                description: 'A test book',
+                author: 'Test Author',
+                publish_date: '2023-01-01',
+                genre: 'Fiction',
+                cover_image: 'test.jpg'
+            }
+        });
+        const bookData = JSON.parse(bookResponse.payload);
+        testBookId = bookData.id;
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    describe('🔹 POST /seen', () => {
+        it('should return 401 for missing token', async () => {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/seen',
+                payload: {
+                    movie_id: testMovieId,
+                    book_id: null
+                }
+            });
+
+            expect(response.statusCode).toBe(401);
+        });
+
+        it('should return 400 for invalid data (missing movie_id and book_id)', async () => {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/seen',
+                headers: {
+                    authorization: `Bearer ${userToken}`
+                },
+                payload: {
+                    movie_id: null,
+                    book_id: null
+                }
+            });
+
+            expect(response.statusCode).toBe(400);
+            const errorResponse = JSON.parse(response.payload);
+            expect(errorResponse.message).toBe('Either movie_id or book_id must be provided');
+        });
+
+        it('should create a seen record for movie', async () => {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/seen',
+                headers: {
+                    authorization: `Bearer ${userToken}`
+                },
+                payload: {
+                    movie_id: testMovieId,
+                    book_id: null
+                }
+            });
+
+            expect(response.statusCode).toBe(200);
+            const seen = JSON.parse(response.payload);
+            expect(seen.movie_id).toBe(testMovieId);
+            expect(seen.book_id).toBeNull();
+            testSeenId = seen.id;
+        });
+
+        it('should create a seen record for book', async () => {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/seen',
+                headers: {
+                    authorization: `Bearer ${anotherUserToken}`
+                },
+                payload: {
+                    movie_id: null,
+                    book_id: testBookId
+                }
+            });
+
+            expect(response.statusCode).toBe(200);
+            const seen = JSON.parse(response.payload);
+            expect(seen.movie_id).toBeNull();
+            expect(seen.book_id).toBe(testBookId);
+        });
+
+        it('should return 400 for duplicate seen record', async () => {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/seen',
+                headers: {
+                    authorization: `Bearer ${userToken}`
+                },
+                payload: {
+                    movie_id: testMovieId,
+                    book_id: null
+                }
+            });
+
+            expect(response.statusCode).toBe(400);
+            const errorResponse = JSON.parse(response.payload);
+            expect(errorResponse.message).toBe('Seen already exists');
+        });
+    });
+
+    describe('🔹 DELETE /seen/:id', () => {
+        it('should return 401 for missing token', async () => {
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/seen/${testSeenId}`
+            });
+
+            expect(response.statusCode).toBe(401);
+        });
+
+        it('should return 404 for non-existent seen record', async () => {
+            const response = await app.inject({
+                method: 'DELETE',
+                url: '/api/v1/seen/9999',
+                headers: {
+                    authorization: `Bearer ${userToken}`
+                }
+            });
+
+            expect(response.statusCode).toBe(404);
+            const errorResponse = JSON.parse(response.payload);
+            expect(errorResponse.message).toBe('Seen not found');
+        });
+
+        it('should return 403 for non-owner', async () => {
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/seen/${testSeenId}`,
+                headers: {
+                    authorization: `Bearer ${anotherUserToken}`
+                }
+            });
+
+            expect(response.statusCode).toBe(403);
+            const errorResponse = JSON.parse(response.payload);
+            expect(errorResponse.message).toBe('You are not the owner of this seen');
+        });
+
+        it('should delete seen record by owner', async () => {
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/seen/${testSeenId}`,
+                headers: {
+                    authorization: `Bearer ${userToken}`
+                }
+            });
+
+            expect(response.statusCode).toBe(204);
+            expect(response.payload).toBe('');
+        });
+    });
+}); 


### PR DESCRIPTION
### ✨ Changes in `seenControllers.ts`
- Refactored controller to:
  - Return `401` when token is missing or invalid
  - Validate input: either `movie_id` or `book_id` must be present
  - Check for duplicate seen entries
  - Ensure user owns the seen record before deletion
  - Provide consistent HTTP status codes: `200`, `204`, `400`, `403`, `404`, `500`

---

### ✅ Test Suite: `seen.test.ts`
- Used Vitest with Fastify's `inject` for full API-level integration tests.
- Generated unique users (admin, user, another user) using `/register` and signed JWT tokens.
- Covered edge cases and expected behaviors:
  - Token validation (`401`)
  - Input validation (`400`)
  - Ownership rules (`403`)
  - Record not found (`404`)
  - Successful creation and deletion (`200`, `204`)